### PR TITLE
rename package name to openvswitch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     - go get -u github.com/golang/protobuf/{proto,protoc-gen-go}
 
 script:
-    - sudo -E env PATH=$PATH TEST_OVS=1 gotestcover -coverprofile=coverage.txt -covermode=atomic ./ovs ./docker
+    - sudo -E env PATH=$PATH TEST_OVS=1 gotestcover -coverprofile=coverage.txt -covermode=atomic ./openvswitch ./docker
 after_success:
     - bash <(curl -s https://codecov.io/bash)
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,6 @@ clean:
 	-rm -f server/${BINARY}-*
 
 test:
-	sudo -E env PATH=$$PATH TEST_OVS=1 go test -v ./ovs ./docker
+	sudo -E env PATH=$$PATH TEST_OVS=1 go test -v ./openvswitch ./docker
 
 .PHONY: server client test clean

--- a/openvswitch/ovs.go
+++ b/openvswitch/ovs.go
@@ -1,4 +1,4 @@
-package ovs
+package openvswitch
 
 import (
 	"fmt"

--- a/openvswitch/ovs_test.go
+++ b/openvswitch/ovs_test.go
@@ -1,4 +1,4 @@
-package ovs
+package openvswitch
 
 import (
 	"os"


### PR DESCRIPTION
because the name of `ovs` is taken by `go-openvswitch/ovs`'s package name. Rename our package name to `openvswitch`. 