### PR TITLE
support add veth pairs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - PATH="${PROTOC_TARGET}/bin:${PATH}"
     - secure: Tbet2rxD8QgjthAo+bxt41qbF2wUPTx0difGK5p4yQISK/njTuT5cqcxnOa4GIbyKtNtx0EgGnyVcQJiQkmZiF6Sabf0mtqU/CQ4PmVV76e9bHwA/CrTtudibMn16ozxuuxvhNxFOMQEhwcQOkW93M/Q9FZUEw9/CGpRGFfSzuA=
 
-go: 
+go:
      - 1.9.x
 
 before_install:
@@ -25,7 +25,7 @@ before_install:
     - make pb
 
 script:
-    - sudo -E env PATH=$PATH TEST_OVS=1 gotestcover -coverprofile=coverage.txt -covermode=atomic ./...
+    - sudo -E env PATH=$PATH TEST_OVS=1 TEST_VETH=1 gotestcover -coverprofile=coverage.txt -covermode=atomic ./...
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean:
 	-rm -f server/${BINARY}-*
 
 test: pb client server
-	go clean -testcache 
-	sudo -E env PATH=$$PATH TEST_OVS=1 go test -v ./...
+	go clean -testcache
+	sudo -E env PATH=$$PATH TEST_OVS=1 TEST_VETH go test -v ./...
 
 .PHONY: server client test clean

--- a/link/link.go
+++ b/link/link.go
@@ -1,0 +1,82 @@
+// fork from https://github.com/containernetworking/plugins/blob/master/pkg/ip/link_linux.go
+package link
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+func ifaceFromNetlinkLink(l netlink.Link) net.Interface {
+	a := l.Attrs()
+	return net.Interface{
+		Index:        a.Index,
+		MTU:          a.MTU,
+		Name:         a.Name,
+		HardwareAddr: a.HardwareAddr,
+		Flags:        a.Flags,
+	}
+}
+
+func makeVethPair(name, peer string, mtu int) (netlink.Link, error) {
+	veth := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  name,
+			Flags: net.FlagUp,
+			MTU:   mtu,
+		},
+		PeerName: peer,
+	}
+	if err := netlink.LinkAdd(veth); err != nil {
+		return nil, err
+	}
+	// Re-fetch the link to get its creation-time parameters, e.g. index and mac
+	veth2, err := netlink.LinkByName(name)
+	if err != nil {
+		netlink.LinkDel(veth) // try and clean up the link if possible.
+		return nil, err
+	}
+	return veth2, nil
+}
+
+// SetupVeth sets up a pair of virtual ethernet devices.
+// Call SetupVeth from inside the container netns.  It will create both veth
+// devices and move the host-side veth into the provided hostNS namespace.
+// On success, SetupVeth returns (hostVeth, containerVeth, nil)
+func SetupVeth(contVethName, hostVethName string, mtu int, hostNS ns.NetNS) (net.Interface, net.Interface, error) {
+	contVeth, err := makeVethPair(contVethName, hostVethName, mtu)
+	if err != nil {
+		return net.Interface{}, net.Interface{}, err
+	}
+
+	if err = netlink.LinkSetUp(contVeth); err != nil {
+		return net.Interface{}, net.Interface{}, fmt.Errorf("failed to set %q up: %v", contVethName, err)
+	}
+
+	hostVeth, err := netlink.LinkByName(hostVethName)
+	if err != nil {
+		return net.Interface{}, net.Interface{}, fmt.Errorf("failed to lookup %q: %v", hostVethName, err)
+	}
+
+	if err = netlink.LinkSetNsFd(hostVeth, int(hostNS.Fd())); err != nil {
+		return net.Interface{}, net.Interface{}, fmt.Errorf("failed to move veth to host netns: %v", err)
+	}
+
+	err = hostNS.Do(func(_ ns.NetNS) error {
+		hostVeth, err = netlink.LinkByName(hostVethName)
+		if err != nil {
+			return fmt.Errorf("failed to lookup %q in %q: %v", hostVethName, hostNS.Path(), err)
+		}
+
+		if err = netlink.LinkSetUp(hostVeth); err != nil {
+			return fmt.Errorf("failed to set %q up: %v", hostVethName, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return net.Interface{}, net.Interface{}, err
+	}
+	return ifaceFromNetlinkLink(hostVeth), ifaceFromNetlinkLink(contVeth), nil
+}

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMakeVethPair(t *testing.T) {
+func TestmakeVethPair(t *testing.T) {
 	if _, ok := os.LookupEnv("TEST_VETH"); !ok {
 		t.SkipNow()
 	}
@@ -18,6 +18,15 @@ func TestMakeVethPair(t *testing.T) {
 
 	assert.Equal(t, "test-veth-ns1", contVeth.Attrs().Name)
 	assert.Equal(t, 1500, contVeth.Attrs().MTU)
+}
+
+func TestInvalidmakeVethPair(t *testing.T) {
+	if _, ok := os.LookupEnv("TEST_VETH"); !ok {
+		t.SkipNow()
+	}
+	_, err := makeVethPair("test-veth-ns1", "test-ovs-1", -1800)
+	// Err: numerical result out of range
+	assert.Error(t, err)
 }
 
 func TestSetupVeth(t *testing.T) {

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -70,14 +70,8 @@ func TestInvalidSetupVeth(t *testing.T) {
 
 	err = netns.Do(func(hostNS ns.NetNS) error {
 		// create the veth pair in the container and move host end into host netns
-		hostVeth, containerVeth, err := SetupVeth(contIfName, hostVethName, 1500, hostNS)
+		_, _, err := SetupVeth(contIfName, hostVethName, -1500, hostNS)
 		assert.Error(t, err)
-
-		assert.Nil(t, containerVeth)
-		assert.Nil(t, hostVeth)
 		return nil
 	})
-	hostVeth, err := netlink.LinkByName(hostVethName)
-	assert.Error(t, err)
-	assert.Nil(t, hostVeth)
 }

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
 )
 
 func TestmakeVethPair(t *testing.T) {

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -1,0 +1,43 @@
+package link
+
+import (
+	"os"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeVethPair(t *testing.T) {
+	if _, ok := os.LookupEnv("TEST_VETH"); !ok {
+		t.SkipNow()
+	}
+	contVeth, err := makeVethPair("test-veth-ns1", "test-ovs-1", 1500)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "test-veth-ns1", contVeth.Attrs().Name)
+	assert.Equal(t, 1500, contVeth.Attrs().MTU)
+}
+
+func TestSetupVeth(t *testing.T) {
+	if _, ok := os.LookupEnv("TEST_VETH"); !ok {
+		t.SkipNow()
+	}
+	contIfName := "test-net0"
+	hostVethName := "test-ovs-0"
+
+	// Create a network namespace
+	netns, err := testutils.NewNS()
+	assert.NoError(t, err)
+
+	err = netns.Do(func(hostNS ns.NetNS) error {
+		// create the veth pair in the container and move host end into host netns
+		hostVeth, containerVeth, err := SetupVeth(contIfName, hostVethName, 1500, hostNS)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "test-net0", containerVeth.Name)
+		assert.Equal(t, "test-ovs-0", hostVeth.Name)
+		return nil
+	})
+}

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -18,15 +18,17 @@ func TestmakeVethPair(t *testing.T) {
 
 	assert.Equal(t, "test-veth-ns1", contVeth.Attrs().Name)
 	assert.Equal(t, 1500, contVeth.Attrs().MTU)
+	defer netlink.LinkDel(contVeth)
 }
 
 func TestInvalidmakeVethPair(t *testing.T) {
 	if _, ok := os.LookupEnv("TEST_VETH"); !ok {
 		t.SkipNow()
 	}
-	_, err := makeVethPair("test-veth-ns1", "test-ovs-1", -1800)
+	contVeth, err := makeVethPair("invalid-test-veth-ns1", "invalid-test-ovs-1", -1800)
 	// Err: numerical result out of range
 	assert.Error(t, err)
+	defer netlink.LinkDel(contVeth)
 }
 
 func TestSetupVeth(t *testing.T) {
@@ -49,4 +51,7 @@ func TestSetupVeth(t *testing.T) {
 		assert.Equal(t, "test-ovs-0", hostVeth.Name)
 		return nil
 	})
+	hostVeth, err := netlink.LinkByName(hostVethName)
+	assert.NoError(t, err)
+	defer netlink.LinkDel(hostVeth)
 }

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -15,11 +15,11 @@ func TestmakeVethPair(t *testing.T) {
 		t.SkipNow()
 	}
 	contVeth, err := makeVethPair("test-veth-ns1", "test-ovs-1", 1500)
+	defer netlink.LinkDel(contVeth)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "test-veth-ns1", contVeth.Attrs().Name)
 	assert.Equal(t, 1500, contVeth.Attrs().MTU)
-	defer netlink.LinkDel(contVeth)
 }
 
 func TestInvalidmakeVethPair(t *testing.T) {
@@ -29,7 +29,7 @@ func TestInvalidmakeVethPair(t *testing.T) {
 	contVeth, err := makeVethPair("invalid-test-veth-ns1", "invalid-test-ovs-1", -1800)
 	// Err: numerical result out of range
 	assert.Error(t, err)
-	defer netlink.LinkDel(contVeth)
+	assert.Nil(t, contVeth)
 }
 
 func TestSetupVeth(t *testing.T) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -111,6 +111,48 @@
 			"revisionTime": "2018-05-01T17:05:46Z"
 		},
 		{
+			"checksumSHA1": "O7JSpVlZNZIiiI6pspfw/HmzW1g=",
+			"path": "github.com/containernetworking/cni/pkg/skel",
+			"revision": "86431d5c16064ec0ce3c215297f5bbf7112fbbde",
+			"revisionTime": "2018-05-31T18:41:59Z"
+		},
+		{
+			"checksumSHA1": "kyeaxrxhMl3XETXxYfjP5dUeMYY=",
+			"path": "github.com/containernetworking/cni/pkg/types",
+			"revision": "86431d5c16064ec0ce3c215297f5bbf7112fbbde",
+			"revisionTime": "2018-05-31T18:41:59Z"
+		},
+		{
+			"checksumSHA1": "lmLYXYR/twmBu+6U678QNF+BQlQ=",
+			"path": "github.com/containernetworking/cni/pkg/types/020",
+			"revision": "86431d5c16064ec0ce3c215297f5bbf7112fbbde",
+			"revisionTime": "2018-05-31T18:41:59Z"
+		},
+		{
+			"checksumSHA1": "pvYIWkqkUeXBuO38Um+v9lQ882M=",
+			"path": "github.com/containernetworking/cni/pkg/types/current",
+			"revision": "86431d5c16064ec0ce3c215297f5bbf7112fbbde",
+			"revisionTime": "2018-05-31T18:41:59Z"
+		},
+		{
+			"checksumSHA1": "HPTtMjgVZDO6r4AdtKHP45m1z48=",
+			"path": "github.com/containernetworking/cni/pkg/version",
+			"revision": "86431d5c16064ec0ce3c215297f5bbf7112fbbde",
+			"revisionTime": "2018-05-31T18:41:59Z"
+		},
+		{
+			"checksumSHA1": "ZM0SnLIE5+Clczod2Md8mVGMz/M=",
+			"path": "github.com/containernetworking/plugins/pkg/ns",
+			"revision": "1d973f59d2a546a77994b1a17e537757dc0acb85",
+			"revisionTime": "2018-05-16T15:54:47Z"
+		},
+		{
+			"checksumSHA1": "dn8XMvhoQkyw+nfwGc2F/0FbqvM=",
+			"path": "github.com/containernetworking/plugins/pkg/testutils",
+			"revision": "1d973f59d2a546a77994b1a17e537757dc0acb85",
+			"revisionTime": "2018-05-16T15:54:47Z"
+		},
+		{
 			"checksumSHA1": "CSPbwbyzqA6sfORicn4HFtIhF/c=",
 			"path": "github.com/davecgh/go-spew/spew",
 			"revision": "8991bc29aa16c548c550c7ff78260e27b9ab7c73",
@@ -237,6 +279,24 @@
 			"revisionTime": "2018-03-14T08:05:35Z"
 		},
 		{
+			"checksumSHA1": "sZaLgMMf+AKwGE8mMvwdDCpHsQA=",
+			"path": "github.com/vishvananda/netlink",
+			"revision": "7c0b5944a3036fc8dc9f4cbf2f5c76dedd29af8b",
+			"revisionTime": "2018-04-08T13:56:38Z"
+		},
+		{
+			"checksumSHA1": "wN69Ln5aaBlq9NHYjowdyOAhbTQ=",
+			"path": "github.com/vishvananda/netlink/nl",
+			"revision": "7c0b5944a3036fc8dc9f4cbf2f5c76dedd29af8b",
+			"revisionTime": "2018-04-08T13:56:38Z"
+		},
+		{
+			"checksumSHA1": "qf37dJzNS2iXycH62ukEw+cleZY=",
+			"path": "github.com/vishvananda/netns",
+			"revision": "be1fbeda19366dea804f00efff2dd73a1642fdcc",
+			"revisionTime": "2017-11-10T22:28:10Z"
+		},
+		{
 			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
 			"path": "golang.org/x/net/context",
 			"revision": "1e491301e022f8f977054da4c2d852decd59571f",
@@ -295,6 +355,12 @@
 			"path": "golang.org/x/net/trace",
 			"revision": "1e491301e022f8f977054da4c2d852decd59571f",
 			"revisionTime": "2018-05-30T06:29:46Z"
+		},
+		{
+			"checksumSHA1": "VUb+SqeoloAw1A2Jz9IzkDNs06c=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "c11f84a56e43e20a78cee75a7c034031ecf57d1f",
+			"revisionTime": "2018-05-25T13:55:20Z"
 		},
 		{
 			"checksumSHA1": "m5QCvoZ2KaoLTG9VWjYNonM08b8=",


### PR DESCRIPTION
Fork and modify from `containernetworking/plugins` support to create veth pairs. Given the container's vethName, host's VethName, mtu and host network namespace.  

APIs
- `makeVethPair(name, peer string, mtu int)` is equivalent

veth name: veth-ns1
peer name: ovs-1
```shell
ip link add name veth-ns1 type veth peer name ovs-1
```
- `SetupVeth(contVethName, hostVethName string, mtu int, hostNS ns.NetNS)` is equivalent 

network namespace name: ns1
veth name: veth-ns1
peer name: ovs-1
```shell
# given a network namespace ns1
# ip netns add ns1
ip link add name veth-ns1 type veth peer name ovs-1
ip link set veth-ns1 netns ns1
```