### PR TITLE
Refactor the openvswitch directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,6 @@ clean:
 
 test: pb client server
 	go clean -testcache
-	sudo -E env PATH=$$PATH TEST_OVS=1 TEST_VETH go test -v ./...
+	sudo -E env PATH=$$PATH TEST_OVS=1 TEST_VETH=1 go test -v ./...
 
 .PHONY: server client vet test clean

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# network-controller [![Build Status](https://travis-ci.org/linkernetworks/network-controller.svg?branch=master)](https://travis-ci.org/linkernetworks/network-controller) [![codecov](https://codecov.io/gh/linkernetworks/network-controller/branch/master/graph/badge.svg)](https://codecov.io/gh/linkernetworks/network-controller)
+# network-controller [![Build Status](https://travis-ci.org/linkernetworks/network-controller.svg?branch=master)](https://travis-ci.org/linkernetworks/network-controller) [![codecov](https://codecov.io/gh/linkernetworks/network-controller/branch/master/graph/badge.svg)](https://codecov.io/gh/linkernetworks/network-controller) [![Go Report Card](https://goreportcard.com/badge/github.com/linkernetworks/network-controller)](https://goreportcard.com/report/github.com/linkernetworks/network-controller)
 
 ## Development
 

--- a/docker/pause-container_test.go
+++ b/docker/pause-container_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestFindK8SPauseContainerID(t *testing.T) {
 	containers := []types.Container{
-		types.Container{
+		{
 			ID:    "18720aa37e71",
 			Names: []string{"k8s_POD_mongo-0_default_553be55e-532c-11e8-bea4-42010af0009f_0"},
 		},
-		types.Container{
+		{
 			ID:    "12332aa37f99",
 			Names: []string{"k8s_POD_redis_default_667be33e-178c-99e2-bea6-68090bd0001d_20"},
 		},
@@ -25,11 +25,11 @@ func TestFindK8SPauseContainerID(t *testing.T) {
 
 func TestFindK8SPauseContainerIDFail(t *testing.T) {
 	containers := []types.Container{
-		types.Container{
+		{
 			ID:    "18720aa37e71",
 			Names: []string{"k8s_POD_mongo-0_default_553be55e-532c-11e8-bea4-42010af0009f_0"},
 		},
-		types.Container{
+		{
 			ID:    "12332aa37f99",
 			Names: []string{"k8s_POD_redis_default_667be33e-178c-99e2-bea6-68090bd0001d_20"},
 		},

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -74,4 +74,5 @@ func TestInvalidSetupVeth(t *testing.T) {
 		assert.Error(t, err)
 		return nil
 	})
+	assert.NoError(t, err)
 }

--- a/openvswitch/ovs_test.go
+++ b/openvswitch/ovs_test.go
@@ -13,9 +13,11 @@ var ovsFile = "/usr/bin/ovs-vsctl"
 var o *OVSManager
 
 func TestMain(m *testing.M) {
-	o = New()
-	retCode := m.Run()
-	os.Exit(retCode)
+	if _, ok := os.LookupEnv("TEST_OVS"); ok {
+		o = New()
+		retCode := m.Run()
+		os.Exit(retCode)
+	}
 }
 
 func changeVSCtl(t *testing.T) os.FileMode {
@@ -32,10 +34,6 @@ func resetVSCtl(mode os.FileMode) {
 }
 
 func TestBridgeOperations(t *testing.T) {
-	if _, ok := os.LookupEnv("TEST_OVS"); !ok {
-		t.SkipNow()
-	}
-
 	bridges, err := o.ListBridges()
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(bridges))
@@ -57,10 +55,6 @@ func TestBridgeOperations(t *testing.T) {
 }
 
 func TestBridgeOperationsFail(t *testing.T) {
-	if _, ok := os.LookupEnv("TEST_OVS"); !ok {
-		t.SkipNow()
-	}
-
 	mode := changeVSCtl(t)
 	defer resetVSCtl(mode)
 
@@ -79,10 +73,6 @@ func TestBridgeOperationsFail(t *testing.T) {
 }
 
 func TestAddDelPort(t *testing.T) {
-	if _, ok := os.LookupEnv("TEST_OVS"); !ok {
-		t.SkipNow()
-	}
-
 	bridgeName := "br0"
 	err := o.CreateBridge(bridgeName)
 	defer o.DeleteBridge(bridgeName)
@@ -108,10 +98,6 @@ func TestAddDelPort(t *testing.T) {
 }
 
 func TestListPortsFail(t *testing.T) {
-	if _, ok := os.LookupEnv("TEST_OVS"); !ok {
-		t.SkipNow()
-	}
-
 	bridgeName := "br0"
 	ports, err := o.ListPorts(bridgeName)
 	assert.Error(t, err)
@@ -133,10 +119,6 @@ func TestAddDelPortFail(t *testing.T) {
 }
 
 func TestFlowOperation(t *testing.T) {
-	if _, ok := os.LookupEnv("TEST_OVS"); !ok {
-		t.SkipNow()
-	}
-
 	bridgeName := "br0"
 	err := o.CreateBridge(bridgeName)
 	defer o.DeleteBridge(bridgeName)
@@ -159,6 +141,7 @@ func TestFlowOperation(t *testing.T) {
 }
 
 func TestFlowOperationsFail(t *testing.T) {
+
 	bridgeName := "br0"
 	err := o.AddFlow(bridgeName, "")
 	assert.Error(t, err)

--- a/server/main.go
+++ b/server/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	pb "github.com/linkernetworks/network-controller/messages"
+	ovs "github.com/linkernetworks/network-controller/openvswitch"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -18,7 +19,9 @@ const (
 )
 
 // server is used to implement messages.NetworkServer.
-type server struct{}
+type server struct {
+	OVS *ovs.OVSManager
+}
 
 func main() {
 	lis, err := net.Listen("tcp", port)
@@ -26,7 +29,7 @@ func main() {
 		log.Fatalf("failed to listen: %v", err)
 	}
 	s := grpc.NewServer()
-	pb.RegisterNetworkControlServer(s, &server{})
+	pb.RegisterNetworkControlServer(s, &server{OVS: ovs.New()})
 	// Register reflection service on gRPC server.
 	reflection.Register(s)
 	if err := s.Serve(lis); err != nil {

--- a/server/netlink-handler.go
+++ b/server/netlink-handler.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 
 	pb "github.com/linkernetworks/network-controller/messages"
-	ovs "github.com/linkernetworks/network-controller/openvswitch"
 	"github.com/linkernetworks/network-controller/utils"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -63,7 +62,7 @@ func (s *server) ConnectBridge(ctx context.Context, req *pb.ConnectBridgeRequest
 		}, err
 	}
 
-	if err := ovs.AddPort(req.BridgeName, hostVethName); err != nil {
+	if err := s.OVS.AddPort(req.BridgeName, hostVethName); err != nil {
 		return &pb.ConnectBridgeResponse{
 			Success: false, Reason: err.Error(),
 		}, err

--- a/server/ovs-handler.go
+++ b/server/ovs-handler.go
@@ -5,7 +5,6 @@ import (
 
 	pb "github.com/linkernetworks/network-controller/messages"
 
-	ovs "github.com/linkernetworks/network-controller/openvswitch"
 	"golang.org/x/net/context"
 )
 
@@ -21,7 +20,7 @@ func (s *server) Ping(ctx context.Context, req *pb.PingRequest) (*pb.PingRespons
 }
 
 func (s *server) AddPort(ctx context.Context, req *pb.AddPortRequest) (*pb.OVSResponse, error) {
-	if err := ovs.AddPort(req.BridgeName, req.IfaceName); err != nil {
+	if err := s.OVS.AddPort(req.BridgeName, req.IfaceName); err != nil {
 		return &pb.OVSResponse{
 			Success: false, Reason: err.Error(),
 		}, err
@@ -30,7 +29,7 @@ func (s *server) AddPort(ctx context.Context, req *pb.AddPortRequest) (*pb.OVSRe
 }
 
 func (s *server) DeletePort(ctx context.Context, req *pb.DeletePortRequest) (*pb.OVSResponse, error) {
-	if err := ovs.DeletePort(req.BridgeName, req.IfaceName); err != nil {
+	if err := s.OVS.DeletePort(req.BridgeName, req.IfaceName); err != nil {
 		return &pb.OVSResponse{
 			Success: false, Reason: err.Error(),
 		}, err
@@ -39,7 +38,7 @@ func (s *server) DeletePort(ctx context.Context, req *pb.DeletePortRequest) (*pb
 }
 
 func (s *server) AddFlow(ctx context.Context, req *pb.AddFlowRequest) (*pb.OVSResponse, error) {
-	if err := ovs.AddFlow(req.BridgeName, req.FlowString); err != nil {
+	if err := s.OVS.AddFlow(req.BridgeName, req.FlowString); err != nil {
 		return &pb.OVSResponse{
 			Success: false, Reason: err.Error(),
 		}, err
@@ -48,7 +47,7 @@ func (s *server) AddFlow(ctx context.Context, req *pb.AddFlowRequest) (*pb.OVSRe
 }
 
 func (s *server) DeleteFlow(ctx context.Context, req *pb.DeleteFlowRequest) (*pb.OVSResponse, error) {
-	if err := ovs.DeleteFlow(req.BridgeName, req.FlowString); err != nil {
+	if err := s.OVS.DeleteFlow(req.BridgeName, req.FlowString); err != nil {
 		return &pb.OVSResponse{
 			Success: false, Reason: err.Error(),
 		}, err

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateVethName(t *testing.T) {
+	o := GenerateVethName("12345678")
+	assert.Equal(t, "vethef797c81", o)
+}


### PR DESCRIPTION
- Create a new object `OVSManager` and it contains the ovs.Client object. 
- All the OVS function is a member function of OVSManager, hence we only init the ovs.Client once for a series OVS operation
- The server side object `server` contains the `OVSManager`