### PR TITLE
Install the openvswitch in the dockerifle.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN govendor sync &&\
 RUN go install ./server/... ./client/...
 
 FROM alpine:3.7
-RUN apk add --no-cache ca-certificates rsync
+RUN apk add --no-cache ca-certificates openvswitch
 WORKDIR /go/bin
 
 COPY --from=0 /go/bin /go/bin


### PR DESCRIPTION
For the container, we will install OpenvSwitch in the alpine environment and mount the hosts' ovsdb.sock into the container. So the container can use the ovs-vsctl to manipulate the hosts' OpenvSwitch.

Example command.
```
sudo docker run -it --rm --mount type=bind,src=/var/run/openvswitch/db.sock,target=/var/run/openvswitch/db.sock,bind-propagation=shared --entrypoint=sh sdnvortex/net-controller
```