### PR TITLE
Fix golint errors

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -11,31 +11,31 @@ import (
 	"google.golang.org/grpc"
 )
 
-type PodOptions struct {
+type podOptions struct {
 	Name string `long:"pName" description:"The Pod Name, can set by environement variable" env:"POD_NAME" required:"true"`
 	NS   string `long:"pNS" description:"The namespace of the Pod, can set by environement variable" env:"POD_NAMESPACE" required:"true"`
 	UUID string `long:"pUUID" description:"The UUID of the Pod, can set by environement variable" env:"POD_UUID" required:"true"`
 }
 
-type InterfaceOptions struct {
+type interfaceOptions struct {
 	IP      string `short:"i" long:"ip" description:"The ip address of the interface, should be CIDR form"`
 	Gateway string `short:"g" long:"gw" description:"The gateway of the inteface subnet"`
 	VLAN    *int   `short:"v" long:"vlan" description:"The Vlan Tag of the interface"`
 }
 
-type ConnectOptions struct {
+type connectOptions struct {
 	Bridge    string `short:"b" long:"bridge" description:"Target bridge name" required:"true"`
 	Interface string `short:"n" long:"nic" description:"The interface name in the container" required:"true"`
 }
 
-type ClientOptions struct {
+type clientOptions struct {
 	Server    string           `short:"s" long:"server " description:"target server address, [ip:port] for TCP or unix://[path] for UNIX" required:"true"`
-	Connect   ConnectOptions   `group:"ConnectOptions"`
-	Interface InterfaceOptions `group:"InterfaceOptions" `
-	Pod       PodOptions       `group:"InterfaceOptions" `
+	Connect   connectOptions   `group:"ConnectOptions"`
+	Interface interfaceOptions `group:"InterfaceOptions" `
+	Pod       podOptions       `group:"InterfaceOptions" `
 }
 
-var options ClientOptions
+var options clientOptions
 var parser = flags.NewParser(&options, flags.Default)
 
 func main() {

--- a/nl/link.go
+++ b/nl/link.go
@@ -1,4 +1,5 @@
 // Package link : fork from https://github.com/containernetworking/plugins/blob/master/pkg/ip/link_linux.go
+
 package nl
 
 import (

--- a/nl/netlink_event.go
+++ b/nl/netlink_event.go
@@ -8,10 +8,10 @@ import (
 
 type NlEventHandler struct {
 	stop              chan struct{}
-	LinkDeleteHandler []LinkReceiver
+	LinkDeleteHandler []linkReceiver
 }
 
-type LinkReceiver func(lu netlink.LinkUpdate) bool
+type linkReceiver func(lu netlink.LinkUpdate) bool
 
 func New() *NlEventHandler {
 	return &NlEventHandler{
@@ -19,7 +19,7 @@ func New() *NlEventHandler {
 	}
 }
 
-func (nl *NlEventHandler) AddDeletedLinkHandler(handler LinkReceiver) {
+func (nl *NlEventHandler) AddDeletedLinkHandler(handler linkReceiver) {
 	nl.LinkDeleteHandler = append(nl.LinkDeleteHandler, handler)
 }
 

--- a/nl/netlink_handler.go
+++ b/nl/netlink_handler.go
@@ -6,13 +6,11 @@ import (
 	"log"
 )
 
-/*
-	Remove the veth from the system.
-	We get the veth name from the netlink.LinkUpdate
-	and traverse all OpenvSwitches and try to remove the veth from its parent OVS
 
-	return true will stop the netlink server handler
-*/
+// RemoveVethFromOVS remove the veth from the ovs.
+// We get the veth name from the netlink.LinkUpdate
+// and traverse all OpenvSwitches and try to remove the veth from its parent OVS
+// return true will stop the netlink server handler
 func RemoveVethFromOVS(lu netlink.LinkUpdate) bool {
 	L := lu.Attrs()
 	if L.ParentIndex != 0 || L.MasterIndex != 0 {


### PR DESCRIPTION
Related to: #34 
- Fix `nl/netlink_event.go`, `nl/netlink_handler.go`, `client/main.go`, `nl/link.go` golint errors

`nl/netlink_event.go` need to be fixed soon, because the function name effect to main function.