### PR TITLE
[Bug] Update the go-openvswich to fix the dump-port functions.

### DIFF
--- a/tests/main.go
+++ b/tests/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"log"
+	"os"
+	"time"
+
+	"github.com/linkernetworks/go-openvswitch/ovs"
+
+	flags "github.com/jessevdk/go-flags"
+	pb "github.com/linkernetworks/network-controller/messages"
+	"google.golang.org/grpc"
+)
+
+type clientOptions struct {
+	Server string `short:"s" long:"server " description:"target server address, [ip:port] for TCP or unix://[path] for UNIX" required:"true"`
+}
+
+var options clientOptions
+var parser = flags.NewParser(&options, flags.Default)
+
+// Testing Variable
+const (
+	bridgeName = "switch1"
+)
+
+//
+
+type TestFunc func(*context.Context, *pb.NetworkControlClient) error
+
+func Test(name string, ctx *context.Context, conn *pb.NetworkControlClient, fun TestFunc) {
+	log.Println("[Start] Testing:", name)
+	if err := fun(ctx, conn); err != nil {
+		log.Fatal("[Fail] Testing:", name, err)
+	}
+	log.Println("[Pass] Testing:", name)
+}
+
+func main() {
+	if _, err := parser.Parse(); err != nil {
+		parser.WriteHelp(os.Stderr)
+		os.Exit(1)
+	}
+
+	log.Println("Start to connect to", options.Server)
+	conn, err := grpc.Dial(options.Server, grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+	log.Println("PASS")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	log.Println("New the Network Controller Client")
+	ncClient := pb.NewNetworkControlClient(conn)
+	if ncClient == nil {
+		log.Fatalf("Init NewNetworkControlClient Fail")
+	}
+	log.Println("PASS")
+
+	Test("ping", &ctx, &ncClient, func(ctx *context.Context, nc *pb.NetworkControlClient) error {
+		_, err := ncClient.Ping(
+			*ctx,
+			&pb.PingRequest{
+				Ping: "Test Ping",
+			},
+		)
+		return err
+	})
+
+	Test("Create Bridge", &ctx, &ncClient, func(ctx *context.Context, nc *pb.NetworkControlClient) error {
+		_, err := ncClient.CreateBridge(
+			*ctx,
+			&pb.CreateBridgeRequest{
+				BridgeName:   bridgeName,
+				DatapathType: "system",
+			},
+		)
+		return err
+	})
+
+	Test("Dump Ports", &ctx, &ncClient, func(ctx *context.Context, nc *pb.NetworkControlClient) error {
+		ports, err := ncClient.DumpPorts(
+			*ctx,
+			&pb.DumpPortsRequest{
+				BridgeName: bridgeName,
+			},
+		)
+
+		ovsPortStats := []ovs.PortStats{}
+		for _, v := range ports.Ports {
+			port := ovs.PortStats{}
+			buf := &bytes.Buffer{}
+			buf.Write(v)
+			err = binary.Read(buf, binary.BigEndian, &port)
+			ovsPortStats = append(ovsPortStats, port)
+		}
+		return err
+	})
+	Test("Delete Bridge", &ctx, &ncClient, func(ctx *context.Context, nc *pb.NetworkControlClient) error {
+		_, err := ncClient.DeleteBridge(
+			*ctx,
+			&pb.DeleteBridgeRequest{
+				BridgeName: bridgeName,
+			},
+		)
+		return err
+	})
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -287,10 +287,10 @@
 			"revisionTime": "2018-03-31T12:42:32Z"
 		},
 		{
-			"checksumSHA1": "QV1GkNjY6f6quzBVonyYp8jP3No=",
+			"checksumSHA1": "sSvvPwRRPM+7CSGLDhtPzFHcC2g=",
 			"path": "github.com/linkernetworks/go-openvswitch/ovs",
-			"revision": "614ef75bf4e8c6de85a736c9086f628a049011ec",
-			"revisionTime": "2018-06-28T09:23:35Z"
+			"revision": "2dd85c7be4f7ad7bae63a8ee2f78e4dfe0aec5d9",
+			"revisionTime": "2018-08-09T09:47:03Z"
 		},
 		{
 			"checksumSHA1": "VnkNO/q6ZVTYCd/F7nmHosHC5a4=",


### PR DESCRIPTION
1. Update the vendor files of go-openvswitch
2. A simple example of gRPC client for some OVS related functions.