### PR TITLE
fix format error

### DIFF
--- a/deploy/server/tcp-daemonset.yaml
+++ b/deploy/server/tcp-daemonset.yaml
@@ -37,7 +37,7 @@ spec:
       - name: docker-sock
         hostPath:
           path: /run/docker.sock
-        name: ovs-data #for some operations(dump ports) it needs extra unix socker to handle, so we mount whole ovs directory
+      - name: ovs-data #for some operations(dump ports) it needs extra unix socker to handle, so we mount whole ovs directory
         hostPath:
           path: /run/openvswitch/
       hostNetwork: true


### PR DESCRIPTION
When I deploy tcp-daemonset.yaml , it happened this error.
```
The DaemonSet "network-controller-server-tcp" is invalid: spec.template.spec.containers[0].volumeMounts[1].name: Not found: "docker-sock"
```

I fix that file format